### PR TITLE
Añadida funcionalidad transchoice

### DIFF
--- a/src/Admin/TranslationAdmin.php
+++ b/src/Admin/TranslationAdmin.php
@@ -80,7 +80,18 @@ class TranslationAdmin extends AbstractAdmin
                 'label' => false,
                 'required' => false,
                 'fields' => [
-                    'value' => []
+                    'value' => [
+                        'field_type' => CKEditorType::class,
+                        'config' => [
+                            'entities' => false,
+                            'enterMode' => 'CKEDITOR.ENTER_BR',
+                            'toolbar' => [
+                                ['Bold', 'Italic'],
+                                ['RemoveFormat'],
+                                ['Link', 'Unlink'],
+                            ],
+                        ],
+                    ],
                 ],
                 'constraints' => [
                     new Assert\Valid(),

--- a/src/Admin/TranslationAdmin.php
+++ b/src/Admin/TranslationAdmin.php
@@ -80,18 +80,7 @@ class TranslationAdmin extends AbstractAdmin
                 'label' => false,
                 'required' => false,
                 'fields' => [
-                    'value' => [
-                        'field_type' => CKEditorType::class,
-                        'config' => [
-                            'entities' => false,
-                            'enterMode' => 'CKEDITOR.ENTER_BR',
-                            'toolbar' => [
-                                ['Bold', 'Italic'],
-                                ['RemoveFormat'],
-                                ['Link', 'Unlink'],
-                            ],
-                        ],
-                    ],
+                    'value' => []
                 ],
                 'constraints' => [
                     new Assert\Valid(),

--- a/src/Service/TranslationService.php
+++ b/src/Service/TranslationService.php
@@ -18,6 +18,9 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class TranslationService
 {
+    private const COUNT_KEY = '%count%';
+    private const COUNT_DELIMITER = '|';
+    
     private $translator;
     private $cache;
     private $requestStack;
@@ -38,7 +41,13 @@ class TranslationService
         $translation = $this->cache->getItem($key);
 
         if (null !== $translation) {
-            return strtr($translation->translate($locale)->getValue(), $parameters);
+            $value = $translation->translate($locale)->getValue();
+            if (array_key_exists(self::COUNT_KEY, $parameters)) {
+                $valueArray = explode(self::COUNT_DELIMITER, $value);
+                $value = ($parameters[self::COUNT_KEY] <= 1) ? $valueArray[0] :$valueArray[1];
+            }
+
+            return strtr($value, $parameters);
         }
 
         return $this->translator->trans($key, $parameters, null, $locale);

--- a/src/Service/TranslationService.php
+++ b/src/Service/TranslationService.php
@@ -20,7 +20,7 @@ class TranslationService
 {
     private const COUNT_KEY = '%count%';
     private const COUNT_DELIMITER = '|';
-    
+
     private $translator;
     private $cache;
     private $requestStack;
@@ -44,7 +44,7 @@ class TranslationService
             $value = $translation->translate($locale)->getValue();
             if (array_key_exists(self::COUNT_KEY, $parameters)) {
                 $valueArray = explode(self::COUNT_DELIMITER, $value);
-                $value = ($parameters[self::COUNT_KEY] <= 1) ? $valueArray[0] :$valueArray[1];
+                $value = ($parameters[self::COUNT_KEY] > 1 && array_key_exists(1, $valueArray)) ? $valueArray[1] : $valueArray[0];
             }
 
             return strtr($value, $parameters);


### PR DESCRIPTION
Se ha modificado el filtro de twig **translate** para permitir pasarle un parámetro **%count%** y dependiendo el valor coger la primera o segunda parte del string, estando dicho string delimitado por el caracter **'|'**